### PR TITLE
use some nasty logic in template to display ward name correctly

### DIFF
--- a/censusreporter/apps/census/templates/profile/profile.html
+++ b/censusreporter/apps/census/templates/profile/profile.html
@@ -3,15 +3,7 @@
 {% comment %}
 {% block head_title %}{% firstof geography.this.full_name geography.this.short_name %} - {{ block.super }}{% endblock %}
 {% endcomment %}}
-{% block head_title %}
-{% spaceless %}
-    {% if geography.level == "ward" %}
-        Ward {{ geography.ward_no }} ({{ geography.code }})
-    {% else %}
-        {{ geography.name }}
-    {% endif %}
-{% endspaceless %} - {{ block.super }}
-{% endblock %}
+{% block head_title %}{{ geography.short_name }} - {{ block.super }}{% endblock %}
 
 {% block head_css_extra %}
 <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
@@ -78,18 +70,7 @@
 
 {% block content %}
 
-<h1>
-    {% spaceless %}
-        {% if geography.level == "ward" %}
-            Ward {{ geography.ward_no }} ({{ geography.code }})
-        {% else %}
-            {{ geography.name }}
-        {% endif %}
-        {% for g in geography.parents %}
-            {% if g.level != "district" %}, {{ g.name }}{% endif %}
-        {% endfor %}
-    {% endspaceless %}
-</h1>
+<h1>{{ geography.long_name }}</h1>
 
 {#}<p class="explain">Indexes show data as a percentage of state and national values, highlighting values that diverge by at least 20%.</p>{#}
 


### PR DESCRIPTION
@longhotsummer I forgot that ward doesn't have a `name` attr. I've implemented the name logic in the template for now, for illustrative purpose. I'd prefer if the logic was in the models instead, i.e. `short_name` and `full_name` properties + a `__unicode__` method. What do you think?

I also excluded the district from the name. For large cities, district and municipality names are often the same and the name gets very long.
