### PR TITLE
Change chloropleth colours, fixes #45

### DIFF
--- a/censusreporter/apps/census/static/js/comparisons.js
+++ b/censusreporter/apps/census/static/js/comparisons.js
@@ -472,7 +472,7 @@ function Comparison(options) {
         
 
         // create the legend
-        var quintileColors = ['#d9ece8', '#a1cfc6', '#68b3a3', '#428476', '#264b44'];
+        var quintileColors = ['#fcbba1', '#fc9272', '#fb6a4a', '#de2d26', '#a50f15'];
         var buildLegend = function(colors) {
             var scaleStops = (values.length >= 5) ? 5 : values.length;
 


### PR DESCRIPTION
Use red colours from http://colorbrewer2.org/

These are still in the brand, but stand out more on the map
and aren't as pale.

![map view table regionofbirth - wazi 2014-10-06 19-37-51](https://cloud.githubusercontent.com/assets/4178542/4530295/8ac8c778-4d7f-11e4-8e52-da0e5d97c203.png)
