### PR TITLE
Simplify embeds

### DIFF
--- a/censusreporter/apps/census/static/iframe.html
+++ b/censusreporter/apps/census/static/iframe.html
@@ -11,7 +11,7 @@
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-48399585-5', 'wazimap.co.za');
+            ga('create', 'UA-48399585-5', 'auto');
         </script>
         <!-- Inline these styles to defeat IE's weird CSS caching for multiple iframes at different widths -->
         <style type="text/css">
@@ -60,6 +60,7 @@
         <!--[if IE 9]>
         <script src="js/vendor/classList.min.js"></script>
         <![endif]-->
+        <script src="js/settings.js"></script>
         <script src="js/charts.js"></script>
         <script src="js/vendor/flippant.min.js"></script>
         <script src="js/embed.chart.frame.js"></script>

--- a/censusreporter/apps/census/static/js/app.js
+++ b/censusreporter/apps/census/static/js/app.js
@@ -37,31 +37,6 @@ $(document).ajaxComplete(function(event, request, settings) {
     spinner.stop();
 });
 
-// standard mapping of summary level code to summary level name
-var sumlevMap = {
-    "country": {"name": "country", "plural": "countries", "sumlev": "country",
-                "children": ['province', 'municipality'],
-                "ancestors": []},
-    "province":  {"name": "province", "plural": "provinces", "sumlev": "province",
-                "children": ['municipality', 'ward'],
-                "ancestors": ['country']},
-    "municipality":  {"name": "municipality", "plural": "municipalities", "sumlev": "municipality",
-                "children": ['ward'],
-                "ancestors": ['province', 'country']},
-    "ward":  {"name": "ward", "plural": "wards", "sumlev": "ward",
-                "children": [],
-                "ancestors": ['municipality', 'province']},
-    "policedistrict":  {"name": "police district", "plural": "police districts", "sumlev": "policedistrict",
-                "children": [],
-                "ancestors": ['province']},
-};
-
-var releaseNames = {
-    'acs2012_1yr': {'name': 'ACS 2012 1-year', 'years': '2012'},
-    'acs2012_3yr': {'name': 'ACS 2012 3-year', 'years': '2010-2012'},
-    'acs2012_5yr': {'name': 'ACS 2012 5-year', 'years': '2008-2012'}
-};
-
 // formatting utils
 // format percentages and/or dollar signs
 var valFmt = function(value, statType, disablePct) {
@@ -161,20 +136,3 @@ var numberWithCommas = function(n) {
     var parts = roundNumber(n).toString().split(".");
     return parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",") + (parts[1] ? "." + parts[1] : "");
 }
-
-// mapit code mappings
-var MAPIT_LEVEL_TYPES = {
-    'country': 'CY',
-    'district': 'DC',
-    'province': 'PR',
-    'municipality': 'MN',
-    'ward': 'WD',
-};
-
-// NB: no simplify tolerance at the country level
-var MAPIT_LEVEL_SIMPLIFY = {
-    'DC': 0.01,
-    'PR': 0.005,
-    'MN': 0.005,
-    'WD': 0.0001,
-};

--- a/censusreporter/apps/census/static/js/charts.js
+++ b/censusreporter/apps/census/static/js/charts.js
@@ -769,8 +769,8 @@ function Chart(options) {
         var querystring = $.param(embedParams);
         
         var embedCode = [
-            '<iframe id="'+embedID+'" class="census-reporter-embed" src="http://embed.wazimap.co.za/static/iframe.html?'+querystring+'" frameborder="0" width="100%" height="300" style="margin: 1em; max-width: '+embedWidth+'px;' + embedAlign + '"></iframe>',
-            '\n<script src="http://embed.wazimap.co.za/static/js/embed.chart.make.js"></script>'
+            '<iframe id="'+embedID+'" class="census-reporter-embed" src="' + EMBED_URL + '/static/iframe.html?'+querystring+'" frameborder="0" width="100%" height="300" style="margin: 1em; max-width: '+embedWidth+'px;' + embedAlign + '"></iframe>',
+            '\n<script src="' + EMBED_URL + '/static/js/embed.chart.make.js"></script>'
         ].join('');
         
         textarea.html(embedCode);

--- a/censusreporter/apps/census/static/js/embed.chart.frame.js
+++ b/censusreporter/apps/census/static/js/embed.chart.frame.js
@@ -21,7 +21,7 @@ function makeEmbedFrame() {
 
         embedFrame.parentContainerID = 'cr-embed-'+embedFrame.params.geoID+'-'+embedFrame.params.chartDataID;
         embedFrame.params.chartDataID = embedFrame.params.chartDataID.split('-');
-        embedFrame.dataSource = 'http://embed.wazimap.co.za/profiles/'+embedFrame.params.geoID+'.json';
+        embedFrame.dataSource = EMBED_URL + '/profiles/'+embedFrame.params.geoID+'.json';
         // avoid css media-query caching issues with multiple embeds on same page
         $('#chart-styles').attr('href','css/charts.css?'+embedFrame.parentContainerID)
 
@@ -106,9 +106,9 @@ function makeEmbedFrame() {
 
         embedFrame.elements.footer.append('a')
             .classed('title', true)
-            .attr('href', 'http://wazimap.co.za/profiles/' + embedFrame.params.geoID + '/')
+            .attr('href', EMBED_URL + '/profiles/' + embedFrame.params.geoID + '/')
             .attr('target', '_blank')
-            .html('<img src="http://embed.wazimap.co.za/static/img/wazi-logo.png"> Wazi');
+            .html('<img src="' + SITE_URL + '/static/img/wazi-logo.png"> Wazimap');
     }
 
     embedFrame.addChartListeners = function() {

--- a/censusreporter/apps/census/static/js/embed.chart.make.js
+++ b/censusreporter/apps/census/static/js/embed.chart.make.js
@@ -1,3 +1,5 @@
+var EMBED_URL = 'http://embed.wazimap.co.za';
+
 function makeCensusEmbeds() {
     var embed = {
         embeds: {}
@@ -68,7 +70,7 @@ function makeCensusEmbeds() {
     embed.sendDataToFrames = function(data) {
         // IE9 can only send strings
         for (var i = 0; i < embed.numContainers; i++) {
-            embed.containers[i].contentWindow.postMessage(JSON.stringify(data), 'http://embed.wazimap.co.za');
+            embed.containers[i].contentWindow.postMessage(JSON.stringify(data), EMBED_URL);
         }
     }
     

--- a/censusreporter/apps/census/static/js/settings.js
+++ b/censusreporter/apps/census/static/js/settings.js
@@ -1,0 +1,47 @@
+var SITE_NAME = 'Wazimap';
+var SITE_URL = 'http://wazimap.co.za';
+// where are embeds hosted?
+// NB: this MUST alse be set in censusreporter/apps/census/static/js/embed.chart.make.js
+var EMBED_URL = 'http://embed.wazimap.co.za';
+
+// standard mapping of summary level code to summary level name
+var sumlevMap = {
+    "country": {"name": "country", "plural": "countries", "sumlev": "country",
+                "children": ['province', 'municipality'],
+                "ancestors": []},
+    "province":  {"name": "province", "plural": "provinces", "sumlev": "province",
+                "children": ['municipality', 'ward'],
+                "ancestors": ['country']},
+    "municipality":  {"name": "municipality", "plural": "municipalities", "sumlev": "municipality",
+                "children": ['ward'],
+                "ancestors": ['province', 'country']},
+    "ward":  {"name": "ward", "plural": "wards", "sumlev": "ward",
+                "children": [],
+                "ancestors": ['municipality', 'province']},
+    "policedistrict":  {"name": "police district", "plural": "police districts", "sumlev": "policedistrict",
+                "children": [],
+                "ancestors": ['province']},
+};
+
+var releaseNames = {
+    'acs2012_1yr': {'name': 'ACS 2012 1-year', 'years': '2012'},
+    'acs2012_3yr': {'name': 'ACS 2012 3-year', 'years': '2010-2012'},
+    'acs2012_5yr': {'name': 'ACS 2012 5-year', 'years': '2008-2012'}
+};
+
+// mapit code mappings
+var MAPIT_LEVEL_TYPES = {
+    'country': 'CY',
+    'district': 'DC',
+    'province': 'PR',
+    'municipality': 'MN',
+    'ward': 'WD',
+};
+
+// NB: no simplify tolerance at the country level
+var MAPIT_LEVEL_SIMPLIFY = {
+    'DC': 0.01,
+    'PR': 0.005,
+    'MN': 0.005,
+    'WD': 0.0001,
+};

--- a/censusreporter/apps/census/templates/_base.html
+++ b/censusreporter/apps/census/templates/_base.html
@@ -25,7 +25,7 @@
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-48399585-5', 'wazimap.co.za');
+            ga('create', 'UA-48399585-5', 'auto');
             ga('send', 'pageview');
 
         </script>
@@ -161,6 +161,7 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.1/jquery.xdomainrequest.min.js"></script>
         <![endif]-->
         
+        <script src="{% static 'js/settings.js' %}"></script>
         <script src="{% static 'js/app.js' %}"></script>
         <script src="{% static 'js/glossary.js' %}"></script>
         <script src="{% static 'js/widget.geo.select.js' %}"></script>

--- a/censusreporter/apps/census/urls.py
+++ b/censusreporter/apps/census/urls.py
@@ -15,7 +15,7 @@ from .wazi import (GeographyDetailView, GeographyJsonView, WardSearchProxy, Plac
 
 admin.autodiscover()
 
-STANDARD_CACHE_TIME = 60*15 # 15-minute cache
+STANDARD_CACHE_TIME = 60*60 # 60-minute cache
 COMPARISON_FORMATS = 'map|table|distribution'
 BLOCK_ROBOTS = getattr(settings, 'BLOCK_ROBOTS', False)
 

--- a/censusreporter/apps/census/wazi.py
+++ b/censusreporter/apps/census/wazi.py
@@ -57,7 +57,6 @@ class GeographyDetailView(BaseGeographyDetailView):
         page_context.update(profile_data)
 
         profile_data_json = SafeString(simplejson.dumps(profile_data, cls=LazyEncoder))
-        self.write_profile_json(profile_data_json)
 
         page_context.update({
             'profile_data_json': profile_data_json
@@ -68,19 +67,6 @@ class GeographyDetailView(BaseGeographyDetailView):
     def get_geography(self, geo_id):
         # stub this out to prevent the subclass for calling out to CR
         pass
-
-    def write_profile_json(self, data):
-        # unversioned, un-zipped embed data
-        key = settings.EMBED_DIR + '/profiles/%s.json' % self.geo_id
-        logger.debug(key)
-        if not os.path.isfile(key):
-            try:
-                # create file object
-                with open(key, 'w+') as f:
-                    f.write(data)
-            except Exception as e:
-                logger.error('Cannot write json data file to disk.', exc_info=e)
-                pass
 
 
 class GeographyJsonView(GeographyDetailView):

--- a/censusreporter/config/base/settings.py
+++ b/censusreporter/config/base/settings.py
@@ -115,4 +115,3 @@ ADMINS = (
 MANAGERS = ADMINS
 
 API_URL = 'http://api.censusreporter.org'
-EMBED_DIR = PROJECT_ROOT + '/embed_data'


### PR DESCRIPTION
Set embed URL at one (well, two) points throughout the site which makes it easier to set.

Don't bother writing profile json to disk, instead rely on Django's file-based cache to do that for us through the normal mechanisms.